### PR TITLE
Display aspect ratio as simplified integer ratio instead of decimal

### DIFF
--- a/js/ResolutionMaster.js
+++ b/js/ResolutionMaster.js
@@ -651,13 +651,28 @@ class ResolutionMasterCanvas {
             const width = this.widthWidget.value;
             const height = this.heightWidget.value;
             const mp = ((width * height) / 1000000).toFixed(2);
-            const aspectRatio = (width / height).toFixed(2);
             const pResolution = this.getClosestPResolution(width, height);
+
+            function gcd(a, b) {
+                while (b !== 0) {
+                    const t = a % b;
+                    a = b;
+                    b = t;
+                }
+                return a;
+            }
+
+            function aspectRatioString(w, h) {
+                const g = gcd(w, h);
+                return `${w / g}:${h / g}`;
+            }
+
+            const aspectRatio = aspectRatioString(width, height);
             
             ctx.fillStyle = "#bbb";
             ctx.font = "12px Arial";
             ctx.textAlign = "center";
-            ctx.fillText(`${width} × ${height}  |  ${mp} MP ${pResolution}  |  ${aspectRatio}:1`,
+            ctx.fillText(`${width} × ${height}  |  ${mp} MP ${pResolution}  |  ${aspectRatio}`,
                         node.size[0] / 2, y);
         }
     }


### PR DESCRIPTION
Display aspect ratio as simplified integer ratio (e.g. 16:9) instead of decimal

- Add gcd() helper and aspectRatioString() to reduce width:height to lowest terms.
- Replace previous decimal aspect ratio formatting (width/height.toFixed(2) + ":1")
  with the simplified integer ratio string (e.g. "16:9").
- Keep megapixel and pResolution calculations unchanged.
- Improves clarity and correctness of the displayed aspect ratio for common resolutions.

Example:
<img width="246" height="23" alt="image" src="https://github.com/user-attachments/assets/98bef0da-fa66-44d4-aaa5-b78c23d14d2c" />
