### PR TITLE
Fix unreachable pixel-count tiebreaker in find_closest_preset

### DIFF
--- a/core/auto_detect.py
+++ b/core/auto_detect.py
@@ -76,7 +76,7 @@ def find_closest_preset(width, height, presets):
             preset_aspect = orientation_width / orientation_height
             preset_pixels = orientation_width * orientation_height
             aspect_diff = abs(input_aspect - preset_aspect)
-            if aspect_diff < 0.01 or aspect_diff < closest_aspect_diff:
+            if aspect_diff < closest_aspect_diff + 0.01:
                 pixel_diff = abs(math.log(input_pixels / preset_pixels))
                 if aspect_diff < closest_aspect_diff or (
                     abs(aspect_diff - closest_aspect_diff) < 0.01 and pixel_diff < closest_pixel_diff
@@ -140,7 +140,7 @@ def apply_custom_calculation(width, height, category, presets):
         target_height = math.sqrt(target_pixels / aspect)
         return {"width": round(target_height * aspect), "height": round(target_height)}
 
-    if category in ("SDXL", "HiDream Dev"):
+    if category in ("SDXL", "HiDream Dev", "Krea 2 Turbo", "Krea 2 RAW"):
         closest = find_closest_preset(width, height, presets)
         if not closest:
             return {"width": width, "height": height}

--- a/core/auto_detect.py
+++ b/core/auto_detect.py
@@ -140,7 +140,7 @@ def apply_custom_calculation(width, height, category, presets):
         target_height = math.sqrt(target_pixels / aspect)
         return {"width": round(target_height * aspect), "height": round(target_height)}
 
-    if category in ("SDXL", "HiDream Dev", "Krea 2 Turbo", "Krea 2 RAW"):
+    if category in ("SDXL", "HiDream Dev"):
         closest = find_closest_preset(width, height, presets)
         if not closest:
             return {"width": width, "height": height}

--- a/core/auto_detect.py
+++ b/core/auto_detect.py
@@ -7,6 +7,9 @@ from .log_system import create_module_logger
 log = create_module_logger(__name__)
 
 
+ASPECT_RATIO_TOLERANCE = 0.01
+
+
 def safe_int(value, default=0):
     try:
         return int(value)
@@ -62,9 +65,7 @@ def find_closest_preset(width, height, presets):
 
     input_aspect = width / height
     input_pixels = width * height
-    closest = None
-    closest_aspect_diff = math.inf
-    closest_pixel_diff = math.inf
+    candidates = []
 
     for preset_name, preset in presets.items():
         preset_width = safe_int(preset.get("width") if isinstance(preset, dict) else None)
@@ -76,16 +77,30 @@ def find_closest_preset(width, height, presets):
             preset_aspect = orientation_width / orientation_height
             preset_pixels = orientation_width * orientation_height
             aspect_diff = abs(input_aspect - preset_aspect)
-            if aspect_diff < closest_aspect_diff + 0.01:
-                pixel_diff = abs(math.log(input_pixels / preset_pixels))
-                if aspect_diff < closest_aspect_diff or (
-                    abs(aspect_diff - closest_aspect_diff) < 0.01 and pixel_diff < closest_pixel_diff
-                ):
-                    closest_aspect_diff = aspect_diff
-                    closest_pixel_diff = pixel_diff
-                    closest = {"name": preset_name, "width": orientation_width, "height": orientation_height}
+            candidates.append(
+                {
+                    "name": preset_name,
+                    "width": orientation_width,
+                    "height": orientation_height,
+                    "aspect_diff": aspect_diff,
+                    "pixel_diff": abs(math.log(input_pixels / preset_pixels)),
+                }
+            )
 
-    return closest
+    if not candidates:
+        return None
+
+    minimum_aspect_diff = min(candidate["aspect_diff"] for candidate in candidates)
+    aspect_matched_candidates = (
+        candidate
+        for candidate in candidates
+        if candidate["aspect_diff"] <= minimum_aspect_diff + ASPECT_RATIO_TOLERANCE
+    )
+    closest = min(
+        aspect_matched_candidates,
+        key=lambda candidate: (candidate["pixel_diff"], candidate["aspect_diff"]),
+    )
+    return {"name": closest["name"], "width": closest["width"], "height": closest["height"]}
 
 
 def apply_flux_like_calculation(width, height, max_mp, max_dim, min_dim, multiple):

--- a/tests/test_auto_detect.py
+++ b/tests/test_auto_detect.py
@@ -1,0 +1,32 @@
+import unittest
+
+from core.auto_detect import find_closest_preset
+
+
+class FindClosestPresetTests(unittest.TestCase):
+    def test_equal_aspect_ratio_uses_pixel_count_tiebreaker(self):
+        presets = {
+            "small": {"width": 1200, "height": 800},
+            "large": {"width": 1500, "height": 1000},
+        }
+
+        closest = find_closest_preset(1600, 1000, presets)
+
+        self.assertEqual(closest, {"name": "large", "width": 1500, "height": 1000})
+
+    def test_selection_is_independent_of_preset_order(self):
+        presets = {
+            "A": {"width": 402, "height": 400},
+            "B": {"width": 759, "height": 750},
+            "C": {"width": 1021, "height": 1000},
+        }
+
+        forward = find_closest_preset(1000, 1000, presets)
+        reversed_order = find_closest_preset(1000, 1000, dict(reversed(list(presets.items()))))
+
+        self.assertEqual(forward, reversed_order)
+        self.assertEqual(forward["name"], "B")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The inner tiebreak for presets with equal aspect ratios could never
run because the outer gate rejected exact aspect ties. Multi-tier
categories (e.g. ZImageTurbo) always snapped to whichever preset came
first in dict order regardless of pixel count.
